### PR TITLE
Update clubs.yml

### DIFF
--- a/_data/clubs.yml
+++ b/_data/clubs.yml
@@ -2,7 +2,7 @@
   president: Lionel Onofri
 
 - name: Les Piafs-MJC
-  president: Ralph Rodriguez
+  president: Ludovic COUTURAUD
   website:
     url: http://piafs.mjcvillebon.org/
     title: 'site du club-école "les Piafs-MJC de Villebon"'


### PR DESCRIPTION
Le nom du président des Piafs MJC est Ludovic COUTURAUD et non Ralph Rodriguez.
Thierry